### PR TITLE
Introducing configurable file type support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Customize settings via "Preferences - Package Settings - SublimeRtags - Settings
 
   /* Max number of jump steps */
   "jump_limit": 10,
+
+  /* Supported source file types */
+  "file_types": ["source.c", "source.c++", "source.c++.11"],
 }
 ```
 

--- a/sublime-rtags.sublime-settings
+++ b/sublime-rtags.sublime-settings
@@ -7,4 +7,7 @@
 
   /* max number of jump steps */
   "jump_limit": 10,
+
+   /* Supported source file types */
+  "file_types": ["source.c", "source.c++", "source.c++.11"]
 }


### PR DESCRIPTION
RTags supports C/C++ and ObjectiveC (even ObjectiveC++) and additionally, users may chose to use C++11 specific source.types.

For allowing a more flexible setup, supported file types can be now get adjusted in the settings.