### PR TITLE
Added ability to provide multiple user defined switches to the rc command.

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
-  {"keys": ["ctrl+shift+u"], "command": "rtags_location", "args": {"switch": "-r"} },
-  {"keys": ["ctrl+shift+i"], "command": "rtags_cursor", "args": {"switch": "-U"} },
-  {"keys": ["f2"], "command": "rtags_location", "args": {"switch": "-f"} },
+  {"keys": ["ctrl+shift+u"], "command": "rtags_location", "args": {"switches": ["--absolute-path", "-r"]} },
+  {"keys": ["ctrl+shift+i"], "command": "rtags_cursor", "args": {"switches": ["-U"]} },
+  {"keys": ["f2"], "command": "rtags_location", "args": {"switches": ["--absolute-path", "-f"]} },
   {"keys": ["ctrl+shift+b"], "command": "rtags_go_backward" },
 ]

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Customize your own keybindings via "Preferences - Package Settings - SublimeRtag
 
 ```
 [
-  {"keys": ["ctrl+shift+u"], "command": "rtags_location", "args": {"switch": "-r"} },
-  {"keys": ["f2"], "command": "rtags_location", "args": {"switch": "-f"} },
+  {"keys": ["ctrl+shift+u"], "command": "rtags_location", "args": {"switches": ["--absolute-path", "-r"]} },
+  {"keys": ["f2"], "command": "rtags_location", "args": {"switches": ["--absolute-path", "-f"]} },
   {"keys": ["ctrl+shift+b"], "command": "rtags_go_backward" },
 ]
 ```


### PR DESCRIPTION
Allows keymap configurations to supply multiple command-line switches to invocations of `rc`. This might be useful for all kinds of customized configurations.
In particular projects may require `rc` to get invoked with the switch `--absolute-path` to force resulting file locations to be returned as absolute paths.