### PR TITLE
Add timeout to rc communicate call

### DIFF
--- a/rtags.py
+++ b/rtags.py
@@ -20,7 +20,7 @@ def run_rc(switches, input=None, *args):
                          stdout=subprocess.PIPE,
                          stdin=subprocess.PIPE)
     print(' '.join(p.args))
-    return p.communicate(input=input)
+    return p.communicate(input=input, timeout=.5)
 
 # TODO refactor somehow to remove global vars
 


### PR DESCRIPTION
If `rdm` is still indexing, `rc` won't get a reply until it's done. This hangs Sublime Text and you have to force quit. Add a timeout to bail out if we don't get a reply in time.