### PR TITLE
Added RC communicate call timeout setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Customize settings via "Preferences - Package Settings - SublimeRtags - Settings
   /* Path to rc utility if not found in $PATH */
   "rc_path": "/home/ramp/mnt/git/rtags/build/bin/rc",
 
+  /* Seconds for rc utility communication timeout default */
+  "rc_timeout": 0.5,
+
   /* Path to rdm daemon if not found in $PATH */
   "rdm_path": "",
 

--- a/rtags.py
+++ b/rtags.py
@@ -15,12 +15,16 @@ RC_PATH = ''
 
 
 def run_rc(switches, input=None, *args):
+    timeout = 0.5
+    if settings != None:
+        timeout = settings.get('rc_timeout', timeout)
+
     p = subprocess.Popen([RC_PATH] + switches + list(args),
                          stderr=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stdin=subprocess.PIPE)
     print(' '.join(p.args))
-    return p.communicate(input=input, timeout=.5)
+    return p.communicate(input=input, timeout=timeout)
 
 # TODO refactor somehow to remove global vars
 

--- a/sublime-rtags.sublime-settings
+++ b/sublime-rtags.sublime-settings
@@ -2,6 +2,9 @@
   /* Path to rc utility if not found in $PATH */
   "rc_path": "/home/ramp/bin/rc",
 
+  /* Seconds for rc utility communication timeout default */
+  "rc_timeout": 0.5,
+
   /* Path to rdm daemon if not found in $PATH */
   "rdm_path": "",
 


### PR DESCRIPTION
Adds new 'rc_timout' setting allowing timeout adjustments. 
For big projects or machines that are generally being under greater load, the preset of 0.5 seconds for the RC communication timeout may be too little.
