### PR TITLE
Fixed "Not indexed" leads to "list index out of range".

### DIFF
--- a/rtags.py
+++ b/rtags.py
@@ -171,7 +171,23 @@ class RtagsBaseCommand(sublime_plugin.TextCommand):
     def _query(self, *args, **kwargs):
         return ''
 
+    def _validate(self, stdout, stderr):
+        if stdout != b'Not indexed\n':
+            return True
+
+        self.view.window().show_quick_panel(
+            ["Not indexed"],
+            None,
+            sublime.MONOSPACE_FONT,
+            -1,
+            None)
+
+        return False
+
     def _action(self, stdout, stderr):
+        if not self._validate(stdout, stderr):
+            return
+
         # pretty format the results
         items = list(map(lambda x: x.decode('utf-8'), stdout.splitlines()))
         self.last_references = items
@@ -224,6 +240,9 @@ class RtagsSymbolInfoCommand(RtagsLocationCommand):
         return re.match(self.inforeg, item)
 
     def _action(self, out, err):
+        if not self._validate(out, err):
+            return
+
         items = list(map(lambda x: x.decode('utf-8'), out.splitlines()))
         items = list(filter(self.filter_items, items))
 


### PR DESCRIPTION
If files are queried that have not been indexed, we error out to the Python console;
```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 812, in run_
    return self.run(edit, **args)
  File "/Users/till/Library/Application Support/Sublime Text 3/Packages/sublime-rtags/rtags.py", line 145, in run
    self._action(out, err)
  File "/Users/till/Library/Application Support/Sublime Text 3/Packages/sublime-rtags/rtags.py", line 198, in _action
    items = list(map(out_to_items, items))
  File "/Users/till/Library/Application Support/Sublime Text 3/Packages/sublime-rtags/rtags.py", line 196, in out_to_items
    (file, line, _, usage) = re.findall(reg, item)[0]
IndexError: list index out of range
```
Adds a new window popping up when a source file is not indexed by RTags, telling the user about it.
